### PR TITLE
Improve error handling and logging in the build scirpt.

### DIFF
--- a/installer/do_build.ps1
+++ b/installer/do_build.ps1
@@ -20,7 +20,10 @@
 # THE SOFTWARE.
 #
 
+$ErrorActionPreference = 'stop'
+
 #Get parameters
+
 $ScriptDir = Split-Path -parent $MyInvocation.MyCommand.Path
 Import-Module $ScriptDir\..\..\BuildSupport\invoke.psm1
 
@@ -31,7 +34,7 @@ $VerString = $argtable["VerString"]
 $CertName = $argtable["CertName"]
 $Company = $argtable["CompanyName"]
 
-Push-Location msi-installer\installer
+cd msi-installer\installer
 Invoke-CommandChecked "32 bit candle" ($env:WIX + "bin\candle.exe") installer.wxs -dPlatform="x86" ("-dCompany=" + $Company) ("-dPRODUCT_VERSION=" + $VerString) ("-dTAG=" + $BuildTag) -out XenClientTools.wixobj
 Invoke-CommandChecked "32 bit light" ($env:WIX + "bin\light.exe") -sw1076 -ext WixUIExtension XenClientTools.wixobj -out XenClientTools.msi -cc cache -reusecab
 Invoke-CommandChecked "64 bit candle" ($env:WIX + "bin\candle.exe") installer.wxs -dPlatform="x64" ("-dCompany=" + $Company) ("-dPRODUCT_VERSION=" + $VerString) ("-dTAG=" + $BuildTag) -out XenClientTools64.wixobj
@@ -39,4 +42,3 @@ Invoke-CommandChecked "64 bit light" ($env:WIX + "bin\light.exe") -sw1076 -ext W
 Invoke-CommandChecked "sign 32 bit MSI" signtool.exe sign /a /s my /n $CertName /t http://timestamp.verisign.com/scripts/timestamp.dll /d "$Company XenClient Tools Installer" XenClientTools.msi
 Invoke-CommandChecked "sign 64 bit MSI" signtool.exe sign /a /s my /n $CertName /t http://timestamp.verisign.com/scripts/timestamp.dll /d "$Company XenClient Tools Installer" XenClientTools64.msi
 
-Pop-Location


### PR DESCRIPTION
This is dependent on https://github.com/OpenXT/openxt/pull/26 since it uses modules introduced there. However this can be merged later; this repo should still build without this change.

There was some error handling code but the signtool invocation was not checked.
