### PR TITLE
Remove Citrix certificates and use signer's cert

### DIFF
--- a/installer/do_build.ps1
+++ b/installer/do_build.ps1
@@ -42,3 +42,8 @@ Invoke-CommandChecked "64 bit light" ($env:WIX + "bin\light.exe") -sw1076 -ext W
 Invoke-CommandChecked "sign 32 bit MSI" signtool.exe sign /a /s my /n $CertName /t http://timestamp.verisign.com/scripts/timestamp.dll /d "$Company XenClient Tools Installer" XenClientTools.msi
 Invoke-CommandChecked "sign 64 bit MSI" signtool.exe sign /a /s my /n $CertName /t http://timestamp.verisign.com/scripts/timestamp.dll /d "$Company XenClient Tools Installer" XenClientTools64.msi
 
+# Copy Signer's Certificate to ISO
+$CertOutPath = (Convert-Path ..\iso\windows\SupportFiles\) + "ToolsSigner.cer"
+$CertBytes = (dir cert:\CurrentUser\My | where {$_.subject.StartsWith("CN=$CertName")}).export("Cert")
+[system.IO.file]::WriteAllBytes("$CertOutPath",$CertBytes)
+

--- a/iso/windows/unattendedInstall.bat
+++ b/iso/windows/unattendedInstall.bat
@@ -41,8 +41,7 @@ ver | find " 5.1" > nul
 IF %ERRORLEVEL% == 0 (set XP=1) ELSE (set XP=0)
 
 IF %XP% == 0 (
-certutil -addstore -enterprise -f "TrustedPublisher" "%~dp0SupportFiles\cit.cer"
-certutil -addstore -enterprise -f "TrustedPublisher" "%~dp0SupportFiles\cit2.cer"
+certutil -addstore -enterprise -f "TrustedPublisher" "%~dp0SupportFiles\ToolsSigner.cer"
 ) ELSE (
 start "HardwareWizardKiller" /min cscript "%~dp0SupportFiles\WizardKiller.vbs"
 )
@@ -58,8 +57,8 @@ IF "%1" == "/DR" set RESTART=0
 IF %ERRORLEVEL% NEQ 0 set RESTART=0
 
 IF %XP% == 0 (
-certutil -delstore -enterprise "TrustedPublisher" "1dced972d082a6a82ca2a99fbcea3a95"
-certutil -delstore -enterprise "TrustedPublisher" "6d589bf235caa049ca618dc4c2489a82"
+FOR /F "Tokens=3" %%I in ('certutil -dump "%~dp0SupportFiles\ToolsSigner.cer" ^| findstr "Serial Number"') do SET SERIAL=%%I
+certutil -delstore -enterprise "TrustedPublisher" %SERIAL%
 ) ELSE (
 taskkill.exe /f /fi "Windowtitle eq HardwareWizardKiller"
 )


### PR DESCRIPTION
Citrix no longer builds and signs the tools, so no need to keep them. As
the signer cert is now part of the build config, we can use that to
export the signer's certificate to a known filename, which will allow
unattended.bat to work again.

Signed-off-by: Kevin Pearson <kevin.pearson.4@us.af.mil>