### PR TITLE
build: disable validation

### DIFF
--- a/installer/do_build.ps1
+++ b/installer/do_build.ps1
@@ -39,9 +39,9 @@ $env:SIGNTOOLPATH = ($signtool+"\signtool.exe")
 
 cd msi-installer\installer
 Invoke-CommandChecked "32 bit candle" ($env:WIX + "bin\candle.exe") installer.wxs -dPlatform="x86" ("-dCompany=" + $Company) ("-dPRODUCT_VERSION=" + $VerString) ("-dTAG=" + $BuildTag) -out XenClientTools.wixobj
-Invoke-CommandChecked "32 bit light" ($env:WIX + "bin\light.exe") -sw1076 -ext WixUIExtension XenClientTools.wixobj -out OpenXTTools.msi -cc cache -reusecab
+Invoke-CommandChecked "32 bit light" ($env:WIX + "bin\light.exe") -sw1076 -ext WixUIExtension XenClientTools.wixobj -out OpenXTTools.msi -cc cache -reusecab -sval
 Invoke-CommandChecked "64 bit candle" ($env:WIX + "bin\candle.exe") installer.wxs -dPlatform="x64" ("-dCompany=" + $Company) ("-dPRODUCT_VERSION=" + $VerString) ("-dTAG=" + $BuildTag) -out XenClientTools64.wixobj
-Invoke-CommandChecked "64 bit light" ($env:WIX + "bin\light.exe") -sw1076 -ext WixUIExtension XenClientTools64.wixobj -out OpenXTTools64.msi -cc cache -reusecab
+Invoke-CommandChecked "64 bit light" ($env:WIX + "bin\light.exe") -sw1076 -ext WixUIExtension XenClientTools64.wixobj -out OpenXTTools64.msi -cc cache -reusecab -sval
 Invoke-CommandChecked "sign 32 bit MSI" ($signtool+"\signtool.exe") sign /a /s my /n ('"'+$CertName+'"') /t http://timestamp.verisign.com/scripts/timestamp.dll /d "$Company OpenXT Tools Installer" OpenXTTools.msi
 Invoke-CommandChecked "sign 64 bit MSI" ($signtool+"\signtool.exe") sign /a /s my /n ('"'+$CertName+'"') /t http://timestamp.verisign.com/scripts/timestamp.dll /d "$Company OpenXT Tools Installer" OpenXTTools64.msi
 # Copy Signer's Certificate to ISO


### PR DESCRIPTION
Documentation:
https://wixtoolset.org/documentation/manual/v3/overview/light.html

This may be a limitation of the validation system when the build is ran as a
service (buildbot-worker) without Admin privilege:
https://github.com/wixtoolset/issues/issues/3968

Since running `smoke.exe`
(https://wixtoolset.org/documentation/manual/v3/overview/alltools.html)
in a command console, using the same de-privileged user,
succeeds, this is likely something wrong in the installer itself
(install.wxs).
